### PR TITLE
✨ Add script to unlink all nix store symlinks

### DIFF
--- a/scripts/unlink-nix-results.bash
+++ b/scripts/unlink-nix-results.bash
@@ -1,0 +1,3 @@
+num=$(find . -name "result*" -type l -lname "/nix/store/*" -prune -print | grep -c /)
+find . -name "result*" -type l -lname "/nix/store/*" -exec unlink {} \;
+echo "Unlinked $num symlinks!"


### PR DESCRIPTION
If you build many things at once you can end up with a bunch of symlinks
in the current folder. This script unlinks all symlinks to the nix store
that starts with "result".

Unclear if I managed to give it execute permissions from wsl.